### PR TITLE
translate `docker-compose -v` into `docker compose version`

### DIFF
--- a/redirect/convert.go
+++ b/redirect/convert.go
@@ -42,7 +42,7 @@ func Convert(args []string) []string {
 			// docker cli has deprecated -h to avoid ambiguity with -H, while docker-compose still support it
 			arg = "--help"
 		}
-		if arg == "--version" {
+		if arg == "--version" || arg == "-v" {
 			// redirect --version pseudo-command to actual command
 			arg = "version"
 		}


### PR DESCRIPTION
Add support for `docker-compose -v`

close https://github.com/docker/compose/issues/8418