### PR TITLE
Fix link for automated installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Compose Switch is a replacement to the Compose V1 `docker-compose` (python) exec
 We provide an script for automated installation:
 
 ```console
-$ curl -fL https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sh
+$ curl -fL https://raw.githubusercontent.com/docker/compose-switch/master/install_on_linux.sh | sh
 ```
 
 ### Manual installation


### PR DESCRIPTION
The link to the automated installer was for compose-cli, not compose-switch