### PR TITLE
Redirect x86_64 architecture

### DIFF
--- a/install_on_linux.sh
+++ b/install_on_linux.sh
@@ -5,6 +5,8 @@ set -e
 ARCHITECTURE=amd64
 if [ "$(uname -m)" = "aarch64" ]; then
   ARCHITECTURE=arm64
+elif [ "$(uname -m)" = "x86_64" ]; then
+  ARCHITECTURE=amd64
 fi  
 COMPOSE_SWITCH_VERSION="v1.0.2"
 COMPOSE_SWITCH_URL="https://github.com/docker/compose-switch/releases/download/${COMPOSE_SWITCH_VERSION}/docker-compose-linux-${ARCHITECTURE}"


### PR DESCRIPTION
My Ubuntu 21.04 install outputs x86_64 for uname -m instead of amd64