### PR TITLE
Makefile: Fix copy-paste mistakes in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ endif
 
 all: bin
 
+PKG_NAME := github.com/docker/compose-switch
 LDFLAGS="-s -w -X $(PKG_NAME)/internal.Version=${GIT_TAG}"
 
 bin:
@@ -15,7 +16,7 @@ cross:
 	CGO_ENABLED=0 GOOS=linux   GOARCH=arm64 go build -ldflags=$(LDFLAGS) -o bin/docker-compose-linux-arm64 .
 
 test:
-	go test -cover $(shell go list  $(TAGS) ./... | grep -vE 'e2e')
+	go test -cover ./...
 
 test-ubuntu-install:
 	docker build -f ubuntu-test.Dockerfile .


### PR DESCRIPTION
Some variables was copied from the compose Makefile without having all
the variables declared. Added `PKG_NAME` so we have working
`internal.Version` and removed the removal of `e2e` tests since they are
not in this repository.

Signed-off-by: Morten Linderud <morten@linderud.pw>