### PR TITLE
Improve root privilege elevation

### DIFF
--- a/install_on_linux.sh
+++ b/install_on_linux.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-
 ARCHITECTURE=amd64
 if [ "$(uname -m)" = "aarch64" ]; then
   ARCHITECTURE=arm64
@@ -11,7 +10,6 @@ COMPOSE_SWITCH_VERSION="v1.0.2"
 COMPOSE_SWITCH_URL="https://github.com/docker/compose-switch/releases/download/${COMPOSE_SWITCH_VERSION}/docker-compose-linux-${ARCHITECTURE}"
 
 error=$(docker compose version 2>&1 >/dev/null)
-echo "After error"
 if [ $? -ne 0 ]; then
   echo "Docker Compose V2 is not installed"
   exit 1


### PR DESCRIPTION
This should enable calling the script without calling sudo on the whole script which breaks the `docker compose` detection for user-only installations