### PR TITLE
Revert "Pass compatibility flag to v2"

### DIFF
--- a/redirect/convert.go
+++ b/redirect/convert.go
@@ -24,8 +24,8 @@ var (
 )
 
 func Convert(args []string) []string {
-	var rootFlags []string
-	command := []string{"compose", "--compatibility"}
+	rootFlags := []string{}
+	command := []string{"compose"}
 	l := len(args)
 	for i := 0; i < l; i++ {
 		arg := args[i]

--- a/redirect/convert_test.go
+++ b/redirect/convert_test.go
@@ -31,43 +31,44 @@ func Test_convert(t *testing.T) {
 		{
 			name: "compose only",
 			args: []string{"up"},
-			want: []string{"compose", "--compatibility", "up"},
+			want: []string{"compose", "up"},
 		},
 		{
 			name: "with context",
 			args: []string{"--context", "foo", "-f", "compose.yaml", "up"},
-			want: []string{"--context", "foo", "compose", "--compatibility", "-f", "compose.yaml", "up"},
+			want: []string{"--context", "foo", "compose", "-f", "compose.yaml", "up"},
 		},
 		{
 			name: "with host",
 			args: []string{"--host", "tcp://1.2.3.4", "up"},
-			want: []string{"--host", "tcp://1.2.3.4", "compose", "--compatibility", "up"},
+			want: []string{"--host", "tcp://1.2.3.4", "compose", "up"},
 		},
 		{
 			name: "compose --version",
 			args: []string{"--version"},
-			want: []string{"compose", "--compatibility", "version"},
+			want: []string{"compose", "version"},
 		},
 		{
 			name: "help",
 			args: []string{"-h"},
-			want: []string{"compose", "--compatibility", "--help"},
+			want: []string{"compose", "--help"},
 		},
 		{
 			name: "issues/1962",
 			args: []string{"psql", "-h", "postgres"},
-			want: []string{"compose", "--compatibility", "psql", "-h", "postgres"}, // -h should not be converted to --help
+			want: []string{"compose", "psql", "-h", "postgres"}, // -h should not be converted to --help
 		},
 		{
 			name: "issues/8648",
 			args: []string{"exec", "mongo", "mongo", "--host", "mongo"},
-			want: []string{"compose", "--compatibility", "exec", "mongo", "mongo", "--host", "mongo"}, // --host is passed to exec
+			want: []string{"compose", "exec", "mongo", "mongo", "--host", "mongo"}, // --host is passed to exec
 		},
 		{
 			name: "issues/12",
 			args: []string{"--log-level", "INFO", "up"},
-			want: []string{"--log-level", "INFO", "compose", "--compatibility", "up"},
+			want: []string{"--log-level", "INFO", "compose", "up"},
 		},
+
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Reverts docker/compose-switch#21

Reverting as this introduces different behaviour in Desktop when using `docker compose` and `docker-compose`.

Fixes #24