### PR TITLE
v1.0.4 released

### DIFF
--- a/install_on_linux.sh
+++ b/install_on_linux.sh
@@ -6,7 +6,7 @@ ARCHITECTURE=amd64
 if [ "$(uname -m)" = "aarch64" ]; then
   ARCHITECTURE=arm64
 fi  
-COMPOSE_SWITCH_VERSION="v1.0.2"
+COMPOSE_SWITCH_VERSION="v1.0.4"
 COMPOSE_SWITCH_URL="https://github.com/docker/compose-switch/releases/download/${COMPOSE_SWITCH_VERSION}/docker-compose-linux-${ARCHITECTURE}"
 
 error=$(docker compose version 2>&1 >/dev/null)


### PR DESCRIPTION
I found that v1.0.4 was released without changing a version string in an install script <https://github.com/docker/compose-switch/releases/tag/v1.0.4>. This pull request fixes the version string.
