### PR TITLE
Cross-compile for non-64-bit ARM processors (ex. Raspberry Pi)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ bin:
 cross:
 	CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build -ldflags=$(LDFLAGS) -o bin/docker-compose-linux-amd64 .
 	CGO_ENABLED=0 GOOS=linux   GOARCH=arm64 go build -ldflags=$(LDFLAGS) -o bin/docker-compose-linux-arm64 .
+	CGO_ENABLED=0 GOOS=linux   GOARCH=arm go build -ldflags=$(LDFLAGS) -o bin/docker-compose-linux-arm .
 
 test:
 	go test -cover ./...


### PR DESCRIPTION
Fixes #20

It looks like the Actions workflow [uses a wildcard to upload every file under `bin/`](https://github.com/docker/compose-switch/blob/2fe0b713c6839e86239e4930b98fe94f3c68f4e2/.github/workflows/release-weekly-build.yml#L36), so the workflow shouldn't need modifying.