### PR TITLE
Continue if docker-compose (v1) is not installed

### DIFF
--- a/install_on_linux.sh
+++ b/install_on_linux.sh
@@ -18,7 +18,7 @@ fi
 curl -fL $COMPOSE_SWITCH_URL -o /usr/local/bin/compose-switch
 chmod +x /usr/local/bin/compose-switch
 
-COMPOSE=$(command -v docker-compose)
+COMPOSE=$(command -v docker-compose || true)
 if [ "$COMPOSE" = /usr/local/bin/docker-compose ]; then
   # This is a manual installation of docker-compose
   # so, safe for us to rename binary


### PR DESCRIPTION
The check at https://github.com/docker/compose-switch/blob/2fe0b713c6839e86239e4930b98fe94f3c68f4e2/install_on_linux.sh#L21 fails if docker-compose (v1) is not installed. Due to the `set -e` the scripts exits at this point.

This fix make sure the script continues.