### PR TITLE
Remove problematic backticks in the install script

### DIFF
--- a/install_on_linux.sh
+++ b/install_on_linux.sh
@@ -31,7 +31,7 @@ if ! command -v $ALTERNATIVES; then
   ALTERNATIVES=alternatives
 fi  
 
-echo "Configuring `docker-compose` alternatives"
+echo "Configuring 'docker-compose' alternatives"
 if [ ! -z $COMPOSE ]; then
   $ALTERNATIVES --install /usr/local/bin/docker-compose docker-compose $COMPOSE 1
 fi  


### PR DESCRIPTION
Backticks will try to execute the string within as a command, but docker-compose may not yet exist at this point, and it seems to be the original intention to simply display information, not run the docker-compose command