### PR TITLE
install_on_linux.sh: install latest release

### DIFF
--- a/install_on_linux.sh
+++ b/install_on_linux.sh
@@ -6,7 +6,7 @@ ARCHITECTURE=amd64
 if [ "$(uname -m)" = "aarch64" ]; then
   ARCHITECTURE=arm64
 fi  
-COMPOSE_SWITCH_VERSION="v1.0.4"
+COMPOSE_SWITCH_VERSION=$(curl -sI https://github.com/docker/compose-switch/releases/latest | grep '^location:' | sed 's,.*/,,')
 COMPOSE_SWITCH_URL="https://github.com/docker/compose-switch/releases/download/${COMPOSE_SWITCH_VERSION}/docker-compose-linux-${ARCHITECTURE}"
 
 error=$(docker compose version 2>&1 >/dev/null)


### PR DESCRIPTION
This updates the install script to fetch the latest release tag from GitHub.

Missed this hard-coded release tag before releasing v1.0.5.
