### PR TITLE
Fix: Fix matching of `Location` HTTP header for older `curl` versions

### DIFF
--- a/install_on_linux.sh
+++ b/install_on_linux.sh
@@ -6,7 +6,7 @@ ARCHITECTURE=amd64
 if [ "$(uname -m)" = "aarch64" ]; then
   ARCHITECTURE=arm64
 fi  
-COMPOSE_SWITCH_VERSION=$(curl -sI https://github.com/docker/compose-switch/releases/latest | grep '^location:' | sed 's,.*/,,' | tr -d '\r')
+COMPOSE_SWITCH_VERSION=$(curl -sI https://github.com/docker/compose-switch/releases/latest | grep -i '^location:' | sed 's,.*/,,' | tr -d '\r')
 COMPOSE_SWITCH_URL="https://github.com/docker/compose-switch/releases/download/${COMPOSE_SWITCH_VERSION}/docker-compose-linux-${ARCHITECTURE}"
 
 if ! docker compose version >/dev/null 2>&1; then


### PR DESCRIPTION
Older version of `curl` might output HTTP headers in uppercase, causing `COMPOSE_SWITCH_VERSION` to be empty and the install script to fail with `404`:

```sh
$ curl -sI https://github.com/docker/compose-switch/releases/latest
HTTP/1.1 302 Found
Server: GitHub.com
Date: Thu, 27 Oct 2022 19:34:39 GMT
Content-Type: text/html; charset=utf-8
Vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
Location: https://github.com/docker/compose-switch/releases/tag/v1.0.5
Cache-Control: no-cache
Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
X-Frame-Options: deny
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Referrer-Policy: no-referrer-when-downgrade
Expect-CT: max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
Content-Security-Policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com wss://*.actions.githubusercontent.com online.visualstudio.com/api/v1/locations github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com identicons.github.com github-cloud.s3.amazonaws.com secured-user-images.githubusercontent.com/ github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
Set-Cookie: _gh_sess=F01z%2FmLqZEOZV1Y0waaCrHpivZp%2BFoZDlDs%2BxskuGB23o8dImsIOGZz59nuJXh0I2KcdF%2B88v2t7kKV%2BQsfMd0BsQr8lUHKsyTtb13ZCzRgygMUzVQgSBYGjklObo8Wx74JlBXgosVOIzSNfdNN2QLWD6tt0Z3G5iRe0lhluHrjHtTtSikaQDJ7rXrJHJbpw5Q%2FPqH2FkqZj2RwBoWaA%2B1JeDZDdmKptikRyeU4sw3IW0a27lkjmOuu6L7XTJifV49bQcMr53CYUN4P7%2F7LaVQ%3D%3D--ixazWaWLj59Z5vJn--yMJtDH2Ugl3b5EBEhhcscw%3D%3D; Path=/; HttpOnly; Secure; SameSite=Lax
Set-Cookie: _octo=GH1.1.1589679474.1666899278; Path=/; Domain=github.com; Expires=Fri, 27 Oct 2023 19:34:38 GMT; Secure; SameSite=Lax
Set-Cookie: logged_in=no; Path=/; Domain=github.com; Expires=Fri, 27 Oct 2023 19:34:38 GMT; HttpOnly; Secure; SameSite=Lax
Content-Length: 0
X-GitHub-Request-Id: 8C66:2030:1CAB4B4:1F7317D:635ADD4E

$ curl --version
curl 7.47.0 (x86_64-pc-linux-gnu) libcurl/7.47.0 GnuTLS/3.4.10 zlib/1.2.8 libidn/1.32 librtmp/2.3
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smb smbs smtp smtps telnet tftp
Features: AsynchDNS IDN IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz TLS-SRP UnixSockets
```

In contrast to newer versions of `curl`:

```sh
$ curl -sI https://github.com/docker/compose-switch/releases/latest
HTTP/2 302
server: GitHub.com
date: Thu, 27 Oct 2022 19:33:53 GMT
content-type: text/html; charset=utf-8
vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
location: https://github.com/docker/compose-switch/releases/tag/v1.0.5
cache-control: no-cache
strict-transport-security: max-age=31536000; includeSubdomains; preload
x-frame-options: deny
x-content-type-options: nosniff
x-xss-protection: 0
referrer-policy: no-referrer-when-downgrade
expect-ct: max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com wss://*.actions.githubusercontent.com online.visualstudio.com/api/v1/locations github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com identicons.github.com github-cloud.s3.amazonaws.com secured-user-images.githubusercontent.com/ github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
set-cookie: _gh_sess=7PndnlLYIbJ3iKPZxpOPcB6PzAy%2FYMQTX1%2BGIiHpl8iNDOykxgwR2fzko4v6xLgCrq5l07iOCge7WAMz5nD%2BtFUWV57wT1dWt9WkVWh81m8PedFr%2BWvaIohltpbmnnU8P4BnV%2FJq3XKxyYC5xSqqWgUu2fK5BOhGdNlBFGKBM6IXc4e4WZ2cqg18aPeJuZbIIoe9JYkXPKdXM%2Bj5SGSaQ7TohiskHwK6fk2SfgLZRcFzEQt5m5CPcuWHQAISi5zCub8nY4gRilay0ybNnm9JKg%3D%3D--5G35WbY2eg9KXqfM--41jARm4Q0ZfWWCD3SfgvNA%3D%3D; Path=/; HttpOnly; Secure; SameSite=Lax
set-cookie: _octo=GH1.1.974386565.1666899233; Path=/; Domain=github.com; Expires=Fri, 27 Oct 2023 19:33:53 GMT; Secure; SameSite=Lax
set-cookie: logged_in=no; Path=/; Domain=github.com; Expires=Fri, 27 Oct 2023 19:33:53 GMT; HttpOnly; Secure; SameSite=Lax
content-length: 0
x-github-request-id: 8C5E:0255:A235A2:B600DD:635ADD21

$ curl --version
curl 7.68.0 (x86_64-pc-linux-gnu) libcurl/7.68.0 OpenSSL/1.1.1f zlib/1.2.11 brotli/1.0.7 libidn2/2.2.0 libpsl/0.21.0 (+libidn2/2.2.0) libssh/0.9.3/openssl/zlib nghttp2/1.40.0 librtmp/2.3
Release-Date: 2020-01-08
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: AsynchDNS brotli GSS-API HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM NTLM_WB PSL SPNEGO SSL TLS-SRP UnixSockets
```

Now `grep` match is case-insensitive to match the `Location` HTTP header correctly for older `curl` versions